### PR TITLE
make isPromiseLike favor of Promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -496,7 +496,7 @@ function callMiddlewareFunction(fn, context, args, next) {
 }
 
 function isPromiseLike(v) {
-  return v instanceof Promise || (typeof v === 'object' && v !== null && typeof v.then === 'function');
+  return (typeof v === 'object' && v !== null && typeof v.then === 'function');
 }
 
 function decorateNextFn(fn) {


### PR DESCRIPTION
This PR renames isPromise to isPromiseLike and checks first if it is an instance of Promise and then does a PromiseLike check. 