### PR TITLE
remove passing error to next

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ Kareem.prototype.execPost = function(name, context, args, options, callback) {
           return callback.apply(null, [error].concat(args));
         }
 
-        next(error);
+        next();
       }
     }
   };


### PR DESCRIPTION
next does not expect an error-parameter. So I removed it. Maybe it is a bigger issue, and you wanted to pass for some reason error to next so that it gets somehow processed?