### PR TITLE
feat: add skipWrappedFunction() annd overwriteResult() to allow changing the wrapped function's result

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,22 @@ function Kareem() {
   this._posts = new Map();
 }
 
+Kareem.skipWrappedFunction = function skipWrappedFunction() {
+  if (!(this instanceof Kareem.skipWrappedFunction)) {
+    return new Kareem.skipWrappedFunction(...arguments);
+  }
+
+  this.args = [...arguments];
+};
+
+Kareem.overwriteResult = function overwriteResult() {
+  if (!(this instanceof Kareem.overwriteResult)) {
+    return new Kareem.overwriteResult(...arguments);
+  }
+
+  this.args = [...arguments];
+};
+
 Kareem.prototype.execPre = function(name, context, args, callback) {
   if (arguments.length === 3) {
     callback = args;
@@ -17,6 +33,7 @@ Kareem.prototype.execPre = function(name, context, args, callback) {
   var asyncPresLeft = numAsyncPres;
   var done = false;
   var $args = args;
+  var shouldSkipWrappedFunction = null;
 
   if (!numPres) {
     return nextTick(function() {
@@ -38,11 +55,15 @@ Kareem.prototype.execPre = function(name, context, args, callback) {
             if (done) {
               return;
             }
-            done = true;
-            return callback(error);
+            if (error instanceof Kareem.skipWrappedFunction) {
+              shouldSkipWrappedFunction = error;
+            } else {
+              done = true;
+              return callback(error);
+            }
           }
           if (--asyncPresLeft === 0 && currentPre >= numPres) {
-            return callback(null);
+            return callback(shouldSkipWrappedFunction);
           }
         })
       ];
@@ -75,7 +96,7 @@ Kareem.prototype.execPre = function(name, context, args, callback) {
             return;
           } else {
             return nextTick(function() {
-              callback(null);
+              callback(shouldSkipWrappedFunction);
             });
           }
         }
@@ -91,8 +112,12 @@ Kareem.prototype.execPre = function(name, context, args, callback) {
       if (done) {
         return;
       }
-      done = true;
-      return callback(error);
+      if (error instanceof Kareem.skipWrappedFunction) {
+        shouldSkipWrappedFunction = error;
+      } else {
+        done = true;
+        return callback(error);
+      }
     }
 
     if (++currentPre >= numPres) {
@@ -100,7 +125,7 @@ Kareem.prototype.execPre = function(name, context, args, callback) {
         // Leave parallel hooks to run
         return;
       } else {
-        return callback(null);
+        return callback(shouldSkipWrappedFunction);
       }
     }
 
@@ -153,6 +178,13 @@ Kareem.prototype.execPost = function(name, context, args, options, callback) {
       if (post.length === numArgs + 2) {
         const _cb = decorateNextFn(function(error) {
           if (error) {
+            if (error instanceof Kareem.overwriteResult) {
+              args = error.args;
+              if (++currentPost >= numPosts) {
+                return callback.call(null, firstError);
+              }
+              return next();
+            }
             firstError = error;
           }
           if (++currentPost >= numPosts) {
@@ -172,6 +204,13 @@ Kareem.prototype.execPost = function(name, context, args, options, callback) {
     } else {
       const _cb = decorateNextFn(function(error) {
         if (error) {
+          if (error instanceof Kareem.overwriteResult) {
+            args = error.args;
+            if (++currentPost >= numPosts) {
+              return callback.apply(null, [null].concat(args));
+            }
+            return next();
+          }
           firstError = error;
           return next();
         }
@@ -203,7 +242,11 @@ Kareem.prototype.execPost = function(name, context, args, options, callback) {
         }
 
         if (isPromiseLike(maybePromiseLike)) {
-          return maybePromiseLike.then(() => _cb(), err => _cb(err));
+          return maybePromiseLike.then((res) => _cb(res), err => _cb(err));
+        }
+
+        if (maybePromiseLike instanceof Kareem.overwriteResult) {
+          args = maybePromiseLike.args;
         }
 
         if (++currentPost >= numPosts) {
@@ -223,8 +266,13 @@ Kareem.prototype.execPostSync = function(name, context, args) {
   const numPosts = posts.length;
 
   for (let i = 0; i < numPosts; ++i) {
-    posts[i].fn.apply(context, args || []);
+    const res = posts[i].fn.apply(context, args || []);
+    if (res instanceof Kareem.overwriteResult) {
+      args = res.args;
+    }
   }
+
+  return args;
 };
 
 Kareem.prototype.createWrapperSync = function(name, fn) {
@@ -234,9 +282,9 @@ Kareem.prototype.createWrapperSync = function(name, fn) {
 
     var toReturn = fn.apply(this, arguments);
 
-    kareem.execPostSync(name, this, [toReturn]);
+    const result = kareem.execPostSync(name, this, [toReturn]);
 
-    return toReturn;
+    return result[0];
   };
 }
 
@@ -252,7 +300,7 @@ function _handleWrapError(instance, error, name, context, args, options, callbac
 
 Kareem.prototype.wrap = function(name, fn, context, args, options) {
   const lastArg = (args.length > 0 ? args[args.length - 1] : null);
-  const argsWithoutCb = Array.from(args);
+  let argsWithoutCb = Array.from(args);
   typeof lastArg === 'function' && argsWithoutCb.pop();
   const _this = this;
 
@@ -260,7 +308,7 @@ Kareem.prototype.wrap = function(name, fn, context, args, options) {
   const checkForPromise = options.checkForPromise;
 
   this.execPre(name, context, args, function(error) {
-    if (error) {
+    if (error && !(error instanceof Kareem.skipWrappedFunction)) {
       const numCallbackParams = options.numCallbackParams || 0;
       const errorArgs = options.contextParameter ? [context] : [];
       for (var i = errorArgs.length; i < numCallbackParams; ++i) {
@@ -272,10 +320,16 @@ Kareem.prototype.wrap = function(name, fn, context, args, options) {
 
     const numParameters = fn.length;
     let ret;
-    try {
-      ret = fn.apply(context, argsWithoutCb.concat(_cb));
-    } catch (err) {
-      return _cb(err);
+
+    if (error instanceof Kareem.skipWrappedFunction) {
+      ret = error.args[0];
+      return _cb(null, ...error.args);
+    } else {
+      try {
+        ret = fn.apply(context, argsWithoutCb.concat(_cb));
+      } catch (err) {
+        return _cb(err);
+      }
     }
 
     if (checkForPromise) {

--- a/test/post.test.js
+++ b/test/post.test.js
@@ -165,6 +165,71 @@ describe('execPost', function() {
       done();
     });
   });
+
+  it('supports overwriteResult', function(done) {
+    hooks.post('cook', function(eggs, callback) {
+      callback(Kareem.overwriteResult(5));
+    });
+
+    hooks.post('cook', function(eggs, callback) {
+      assert.equal(eggs, 5);
+      callback();
+    });
+
+    var options = {};
+    hooks.execPost('cook', null, [4], options, function(error, eggs) {
+      assert.equal(eggs, 5);
+      done();
+    });
+  });
+
+  it('supports sync returning overwriteResult', function(done) {
+    hooks.post('cook', function() {
+      return Kareem.overwriteResult(5);
+    });
+
+    hooks.post('cook', function(eggs, callback) {
+      assert.equal(eggs, 5);
+      callback();
+    });
+
+    var options = {};
+    hooks.execPost('cook', null, [4], options, function(error, eggs) {
+      assert.ifError(error);
+      assert.equal(eggs, 5);
+      done();
+    });
+  });
+
+  it('supports sync overwriteResult', function() {
+    hooks.post('cook', function(eggs) {
+      return Kareem.overwriteResult(5);
+    });
+
+    hooks.post('cook', function(eggs) {
+      assert.equal(eggs, 5);
+    });
+
+    var options = {};
+    const res = hooks.execPostSync('cook', null, [4], options);
+    assert.deepEqual(res, [5]);
+  });
+
+  it('supports overwriteResult with promises', function(done) {
+    hooks.post('cook', function(eggs) {
+      return Promise.resolve(Kareem.overwriteResult(5));
+    });
+
+    hooks.post('cook', function(eggs) {
+      assert.equal(eggs, 5);
+    });
+
+    var options = {};
+    hooks.execPost('cook', null, [4], options, function(error, eggs) {
+      assert.equal(eggs, 5);
+      done();
+    });
+  }); 
 });
 
 describe('execPostSync', function() {

--- a/test/pre.test.js
+++ b/test/pre.test.js
@@ -307,6 +307,24 @@ describe('execPre', function() {
       done();
     });
   });
+
+  it('supports skipWrappedFunction', function(done) {
+    var execed = {};
+
+    hooks.pre('cook', function(callback) {
+      callback(Kareem.skipWrappedFunction(42));
+    });
+
+    hooks.pre('cook', function() {
+      execed.second = true;
+    });
+
+    hooks.execPre('cook', null, function(err) {
+      assert.ok(execed.second);
+      assert.ok(err instanceof Kareem.skipWrappedFunction);
+      done();
+    });
+  });
 });
 
 describe('execPreSync', function() {

--- a/test/wrap.test.js
+++ b/test/wrap.test.js
@@ -287,6 +287,91 @@ describe('wrap()', function() {
       25);
   });
 
+  it('supports overwriteResult', function(done) {
+    hooks.post('cook', function(eggs, callback) {
+      callback(Kareem.overwriteResult(5));
+    });
+
+    const args = [(err, res) => {
+      assert.ifError(err);
+      assert.equal(res, 5);
+      done();
+    }];
+
+    hooks.wrap(
+      'cook',
+      function(callback) {
+        callback(null, 4);
+      },
+      null,
+      args);
+  });
+
+  it('supports skipWrappedFunction', function(done) {
+    const execed = {};
+    hooks.pre('cook', function pre(callback) {
+      execed.pre = true;
+      callback(Kareem.skipWrappedFunction(3));
+    });
+
+    hooks.post('cook', function(res, callback) {
+      assert.equal(res, 3);
+      execed.post = true;
+      callback();
+    });
+
+    const args = [(err, res) => {
+      assert.ifError(err);
+      assert.equal(res, 3);
+      assert.ok(execed.pre);
+      assert.ok(execed.post);
+      assert.ok(!execed.wrapped);
+      done();
+    }];
+
+    hooks.wrap(
+      'cook',
+      function wrapped(callback) {
+        execed.wrapped = true;
+        callback();
+      },
+      null,
+      args);
+  });
+
+  it('supports skipWrappedFunction with arguments', function(done) {
+    const execed = {};
+    hooks.pre('cook', function pre(callback, arg) {
+      execed.pre = true;
+      assert.strictEqual(arg, 4);
+      callback(Kareem.skipWrappedFunction(3));
+    });
+
+    hooks.post('cook', function(res, callback) {
+      assert.equal(res, 3);
+      execed.post = true;
+      callback();
+    });
+
+    const args = [4, (err, res) => {
+      assert.ifError(err);
+      assert.equal(res, 3);
+      assert.ok(execed.pre);
+      assert.ok(execed.post);
+      assert.ok(!execed.wrapped);
+      done();
+    }];
+
+    hooks.wrap(
+      'cook',
+      function wrapped(arg, callback) {
+        execed.wrapped = true;
+        callback();
+      },
+      null,
+      args);
+  });
+
   it('handles post errors with no args', function(done) {
     hooks.pre('cook', function(done) {
       obj.waffles = false;
@@ -362,5 +447,18 @@ describe('wrap()', function() {
     assert.equal(calledPre, 1);
     assert.equal(calledFn, 1);
     assert.equal(calledPost, 1);
+  });
+
+  it('sync wrappers with overwriteResult', function() {
+    hooks.pre('cook', function() {
+    });
+
+    hooks.post('cook', function() {
+      return Kareem.overwriteResult(5);
+    });
+
+    const wrapper = hooks.createWrapperSync('cook', function() { return 4; });
+
+    assert.strictEqual(wrapper(), 5);
   });
 });


### PR DESCRIPTION
Re: Automattic/mongoose#11426
Re: Automattic/mongoose#8393

@Uzlopak what do you think? General idea:

```javascript
schema.post('find', function(res) {
  // Replace `res` with a different object
  return mongoose.overwriteResult(res.filter(v => !v.isDeleted));
});

schema.pre('updateOne', function() {
  // Skip calling `updateOne()`, instead return a hard-coded object
  return mongoose.skipWrappedFunction({ modifiedCount: 3 });
});
```