### PR TITLE
perf: avoid cloning args on every pre/post

### DIFF
--- a/benchmarks/execPost.js
+++ b/benchmarks/execPost.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const Kareem = require('../index');
+
+let sink = 0;
+const numIterations = Number(process.env.KAREEM_BENCH_ITERATIONS || 200000);
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+
+async function run() {
+  const scenarios = [
+    ['1 hook, 1 arg', 1, ['x']],
+    ['5 hooks, 1 arg', 5, ['x']],
+    ['10 hooks, 1 arg', 10, ['x']],
+    ['5 hooks, 3 args', 5, ['x', 42, true]],
+    ['5 hooks, 3 args + callback', 5, ['x', 42, noop]],
+    ['10 hooks, 3 args + callback', 10, ['x', 42, noop]]
+  ];
+
+  const results = [];
+
+  for (const [label, numHooks, args] of scenarios) {
+    const hooks = new Kareem();
+    for (let i = 0; i < numHooks; ++i) {
+      hooks.post('test', function() {
+        sink += arguments.length;
+        if (typeof arguments[0] === 'string') {
+          sink += arguments[0].length;
+        }
+      });
+    }
+
+    for (let i = 0; i < 20000; ++i) {
+      await hooks.execPost('test', null, args);
+    }
+
+    const start = process.hrtime.bigint();
+    for (let i = 0; i < numIterations; ++i) {
+      await hooks.execPost('test', null, args);
+    }
+    const durationNs = process.hrtime.bigint() - start;
+    const totalMs = Number(durationNs) / 1e6;
+
+    results.push({
+      scenario: label,
+      iterations: numIterations,
+      totalMs: +totalMs.toFixed(3),
+      avgUsPerExec: +((totalMs * 1000) / numIterations).toFixed(3)
+    });
+  }
+
+  console.log(JSON.stringify({ results }, null, 2));
+}
+
+function noop() {}
+
+process.on('exit', () => {
+  if (sink === 0) {
+    console.error('unexpected sink value');
+    process.exitCode = 1;
+  }
+});

--- a/benchmarks/execPost.js
+++ b/benchmarks/execPost.js
@@ -16,8 +16,8 @@ async function run() {
     ['5 hooks, 1 arg', 5, ['x']],
     ['10 hooks, 1 arg', 10, ['x']],
     ['5 hooks, 3 args', 5, ['x', 42, true]],
-    ['5 hooks, 3 args + callback', 5, ['x', 42, noop]],
-    ['10 hooks, 3 args + callback', 10, ['x', 42, noop]]
+    ['5 hooks, 2 args + callback', 5, ['x', 42, noop]],
+    ['10 hooks, 2 args + callback', 10, ['x', 42, noop]]
   ];
 
   const results = [];

--- a/benchmarks/execPre.js
+++ b/benchmarks/execPre.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const Kareem = require('../index');
+
+let sink = 0;
+const numIterations = Number(process.env.KAREEM_BENCH_ITERATIONS || 200000);
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+
+async function run() {
+  const scenarios = [
+    ['1 hook, 1 arg', 1, ['x']],
+    ['5 hooks, 1 arg', 5, ['x']],
+    ['10 hooks, 1 arg', 10, ['x']],
+    ['5 hooks, 3 args', 5, ['x', 42, true]],
+    ['5 hooks, 3 args + callback', 5, ['x', 42, noop]],
+    ['10 hooks, 3 args + callback', 10, ['x', 42, noop]]
+  ];
+
+  const results = [];
+
+  for (const [label, numHooks, args] of scenarios) {
+    const hooks = new Kareem();
+    for (let i = 0; i < numHooks; ++i) {
+      hooks.pre('test', function() {
+        sink += arguments.length;
+        if (typeof arguments[0] === 'string') {
+          sink += arguments[0].length;
+        }
+      });
+    }
+
+    for (let i = 0; i < 20000; ++i) {
+      await hooks.execPre('test', null, args);
+    }
+
+    const start = process.hrtime.bigint();
+    for (let i = 0; i < numIterations; ++i) {
+      await hooks.execPre('test', null, args);
+    }
+    const durationNs = process.hrtime.bigint() - start;
+    const totalMs = Number(durationNs) / 1e6;
+
+    results.push({
+      scenario: label,
+      iterations: numIterations,
+      totalMs: +totalMs.toFixed(3),
+      avgUsPerExec: +((totalMs * 1000) / numIterations).toFixed(3)
+    });
+  }
+
+  console.log(JSON.stringify({ results }, null, 2));
+}
+
+function noop() {}
+
+process.on('exit', () => {
+  if (sink === 0) {
+    console.error('unexpected sink value');
+    process.exitCode = 1;
+  }
+});

--- a/benchmarks/execPre.js
+++ b/benchmarks/execPre.js
@@ -16,8 +16,8 @@ async function run() {
     ['5 hooks, 1 arg', 5, ['x']],
     ['10 hooks, 1 arg', 10, ['x']],
     ['5 hooks, 3 args', 5, ['x', 42, true]],
-    ['5 hooks, 3 args + callback', 5, ['x', 42, noop]],
-    ['10 hooks, 3 args + callback', 10, ['x', 42, noop]]
+    ['5 hooks, 2 args + callback', 5, ['x', 42, noop]],
+    ['10 hooks, 2 args + callback', 10, ['x', 42, noop]]
   ];
 
   const results = [];

--- a/index.js
+++ b/index.js
@@ -141,43 +141,38 @@ Kareem.prototype.execPost = async function execPost(name, context, args, options
     return args;
   }
 
+  let cbPromise = null;
+  let resolve;
+  let reject;
+  let newArgs = args.slice();
+  let numArgs = args.length;
+  if (options?.numCallbackParams != null) {
+    numArgs = options.numCallbackParams;
+    for (let i = newArgs.length; i < numArgs; ++i) {
+      newArgs.push(null);
+    }
+  }
+  newArgs.push(function nextCallback(err) {
+    if (err) {
+      reject(err);
+    } else {
+      resolve();
+    }
+  });
+  let errorArgs = options?.error ? [firstError, ...newArgs] : null;
+
   for (const currentPost of posts) {
     const post = currentPost.fn;
-    let numArgs = 0;
-    const newArgs = [];
-    const argLength = args.length;
-    for (let i = 0; i < argLength; ++i) {
-      if (!args[i] || !args[i]._kareemIgnore) {
-        numArgs += 1;
-        newArgs.push(args[i]);
-      }
-    }
-    // If numCallbackParams set, fill in the rest with null to enforce consistent number of args
-    if (options?.numCallbackParams != null) {
-      numArgs = options.numCallbackParams;
-      for (let i = newArgs.length; i < numArgs; ++i) {
-        newArgs.push(null);
-      }
-    }
 
-    let resolve;
-    let reject;
-    const cbPromise = new Promise((_resolve, _reject) => {
+    cbPromise = new Promise((_resolve, _reject) => {
       resolve = _resolve;
       reject = _reject;
-    });
-    newArgs.push(function nextCallback(err) {
-      if (err) {
-        reject(err);
-      } else {
-        resolve();
-      }
     });
 
     if (firstError) {
       if (isErrorHandlingMiddleware(currentPost, numArgs)) {
         try {
-          const res = post.apply(context, [firstError].concat(newArgs));
+          const res = post.apply(context, errorArgs);
           if (isPromiseLike(res)) {
             await res;
           } else if (post.length === numArgs + 2) {
@@ -187,9 +182,25 @@ Kareem.prototype.execPost = async function execPost(name, context, args, options
         } catch (error) {
           if (error instanceof Kareem.overwriteResult) {
             args = error.args;
+            newArgs = args.slice();
+            numArgs = args.length;
+            if (options?.numCallbackParams != null) {
+              numArgs = options.numCallbackParams;
+              for (let i = newArgs.length; i < numArgs; ++i) {
+                newArgs.push(null);
+              }
+            }
+            newArgs.push(function nextCallback(err) {
+              if (err) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
             continue;
           }
           firstError = error;
+          errorArgs = [firstError, ...newArgs];
         }
       } else {
         continue;
@@ -211,14 +222,45 @@ Kareem.prototype.execPost = async function execPost(name, context, args, options
         } catch (error) {
           if (error instanceof Kareem.overwriteResult) {
             args = error.args;
+            newArgs = args.slice();
+            numArgs = args.length;
+            if (options?.numCallbackParams != null) {
+              numArgs = options.numCallbackParams;
+              for (let i = newArgs.length; i < numArgs; ++i) {
+                newArgs.push(null);
+              }
+            }
+            newArgs.push(function nextCallback(err) {
+              if (err) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
             continue;
           }
           firstError = error;
+          errorArgs = [firstError, ...newArgs];
           continue;
         }
 
         if (res instanceof Kareem.overwriteResult) {
           args = res.args;
+          newArgs = args.slice();
+          numArgs = args.length;
+          if (options?.numCallbackParams != null) {
+            numArgs = options.numCallbackParams;
+            for (let i = newArgs.length; i < numArgs; ++i) {
+              newArgs.push(null);
+            }
+          }
+          newArgs.push(function nextCallback(err) {
+            if (err) {
+              reject(err);
+            } else {
+              resolve();
+            }
+          });
           continue;
         }
       }

--- a/index.js
+++ b/index.js
@@ -144,21 +144,18 @@ Kareem.prototype.execPost = async function execPost(name, context, args, options
   let cbPromise = null;
   let resolve;
   let reject;
-  let newArgs = args.slice();
-  let numArgs = args.length;
-  if (options?.numCallbackParams != null) {
-    numArgs = options.numCallbackParams;
-    for (let i = newArgs.length; i < numArgs; ++i) {
-      newArgs.push(null);
-    }
-  }
-  newArgs.push(function nextCallback(err) {
+  const nextCallback = function nextCallback(err) {
     if (err) {
       reject(err);
     } else {
       resolve();
     }
-  });
+  };
+
+  let newArgs = args.slice();
+  _handleNumCallbackParams(newArgs, options?.numCallbackParams);
+  let numArgs = newArgs.length;
+  newArgs.push(nextCallback);
   let errorArgs = options?.error ? [firstError, ...newArgs] : null;
 
   for (const currentPost of posts) {
@@ -183,20 +180,9 @@ Kareem.prototype.execPost = async function execPost(name, context, args, options
           if (error instanceof Kareem.overwriteResult) {
             args = error.args;
             newArgs = args.slice();
-            numArgs = args.length;
-            if (options?.numCallbackParams != null) {
-              numArgs = options.numCallbackParams;
-              for (let i = newArgs.length; i < numArgs; ++i) {
-                newArgs.push(null);
-              }
-            }
-            newArgs.push(function nextCallback(err) {
-              if (err) {
-                reject(err);
-              } else {
-                resolve();
-              }
-            });
+            _handleNumCallbackParams(newArgs, options?.numCallbackParams);
+            numArgs = newArgs.length;
+            newArgs.push(nextCallback);
             continue;
           }
           firstError = error;
@@ -223,20 +209,10 @@ Kareem.prototype.execPost = async function execPost(name, context, args, options
           if (error instanceof Kareem.overwriteResult) {
             args = error.args;
             newArgs = args.slice();
-            numArgs = args.length;
-            if (options?.numCallbackParams != null) {
-              numArgs = options.numCallbackParams;
-              for (let i = newArgs.length; i < numArgs; ++i) {
-                newArgs.push(null);
-              }
-            }
-            newArgs.push(function nextCallback(err) {
-              if (err) {
-                reject(err);
-              } else {
-                resolve();
-              }
-            });
+            _handleNumCallbackParams(newArgs, options?.numCallbackParams);
+            numArgs = newArgs.length;
+            newArgs.push(nextCallback);
+            errorArgs = [firstError, ...newArgs];
             continue;
           }
           firstError = error;
@@ -247,20 +223,9 @@ Kareem.prototype.execPost = async function execPost(name, context, args, options
         if (res instanceof Kareem.overwriteResult) {
           args = res.args;
           newArgs = args.slice();
-          numArgs = args.length;
-          if (options?.numCallbackParams != null) {
-            numArgs = options.numCallbackParams;
-            for (let i = newArgs.length; i < numArgs; ++i) {
-              newArgs.push(null);
-            }
-          }
-          newArgs.push(function nextCallback(err) {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          });
+          _handleNumCallbackParams(newArgs, options?.numCallbackParams);
+          numArgs = newArgs.length;
+          newArgs.push(nextCallback);
           continue;
         }
       }
@@ -273,6 +238,22 @@ Kareem.prototype.execPost = async function execPost(name, context, args, options
 
   return args;
 };
+
+/*!
+ * Handle the `numCallbackParams` option for `execPostSync`: fill `newArgs` with `null` until
+ * length is `numCallbackParams` if `numCallbackParams` is a number.
+ *
+ * @param {Array} newArgs The arguments to fill
+ * @param {number|null|undefined} numCallbackParams The number of callback parameters
+ */
+
+function _handleNumCallbackParams(newArgs, numCallbackParams) {
+  if (typeof numCallbackParams === 'number' && numCallbackParams > newArgs.length) {
+    for (let i = newArgs.length; i < numCallbackParams; ++i) {
+      newArgs.push(null);
+    }
+  }
+}
 
 /**
  * Execute all "post" hooks for "name" synchronously

--- a/index.js
+++ b/index.js
@@ -55,17 +55,8 @@ Kareem.prototype.execPre = async function execPre(name, context, args, options) 
   }
 
   for (const pre of pres) {
-    const args = [];
-    const _args = [null].concat($args);
-    for (let i = 1; i < _args.length; ++i) {
-      if (i === _args.length - 1 && typeof _args[i] === 'function') {
-        continue; // skip callbacks to avoid accidentally calling the callback from a hook
-      }
-      args.push(_args[i]);
-    }
-
     try {
-      const maybePromiseLike = pre.fn.apply(context, args);
+      const maybePromiseLike = pre.fn.apply(context, $args);
       if (isPromiseLike(maybePromiseLike)) {
         const result = await maybePromiseLike;
         if (result instanceof Kareem.overwriteArguments) {


### PR DESCRIPTION
Cloning args on every pre/post was a big drain on performance, especially for `pre()` where we don't have to add callbacks anymore.

Before:

```
{
  "results": [
    {
      "scenario": "1 hook, 1 arg",
      "iterations": 200000,
      "totalMs": 49.221,
      "avgUsPerExec": 0.246
    },
    {
      "scenario": "5 hooks, 1 arg",
      "iterations": 200000,
      "totalMs": 136.745,
      "avgUsPerExec": 0.684
    },
    {
      "scenario": "10 hooks, 1 arg",
      "iterations": 200000,
      "totalMs": 243.199,
      "avgUsPerExec": 1.216
    },
    {
      "scenario": "5 hooks, 3 args",
      "iterations": 200000,
      "totalMs": 137.098,
      "avgUsPerExec": 0.685
    },
    {
      "scenario": "5 hooks, 3 args + callback",
      "iterations": 200000,
      "totalMs": 135.913,
      "avgUsPerExec": 0.68
    },
    {
      "scenario": "10 hooks, 3 args + callback",
      "iterations": 200000,
      "totalMs": 244.986,
      "avgUsPerExec": 1.225
    }
  ]
}

```

After:

```
{
  "results": [
    {
      "scenario": "1 hook, 1 arg",
      "iterations": 200000,
      "totalMs": 34.19,
      "avgUsPerExec": 0.171
    },
    {
      "scenario": "5 hooks, 1 arg",
      "iterations": 200000,
      "totalMs": 45.294,
      "avgUsPerExec": 0.226
    },
    {
      "scenario": "10 hooks, 1 arg",
      "iterations": 200000,
      "totalMs": 64.934,
      "avgUsPerExec": 0.325
    },
    {
      "scenario": "5 hooks, 3 args",
      "iterations": 200000,
      "totalMs": 41.757,
      "avgUsPerExec": 0.209
    },
    {
      "scenario": "5 hooks, 3 args + callback",
      "iterations": 200000,
      "totalMs": 42.56,
      "avgUsPerExec": 0.213
    },
    {
      "scenario": "10 hooks, 3 args + callback",
      "iterations": 200000,
      "totalMs": 61.592,
      "avgUsPerExec": 0.308
    }
  ]
}
```

With post, the difference is less pronounced because we still have lingering callbacks. But still non-trival, before:

```
{
  "results": [
    {
      "scenario": "1 hook, 1 arg",
      "iterations": 200000,
      "totalMs": 38.381,
      "avgUsPerExec": 0.192
    },
    {
      "scenario": "5 hooks, 1 arg",
      "iterations": 200000,
      "totalMs": 98.818,
      "avgUsPerExec": 0.494
    },
    {
      "scenario": "10 hooks, 1 arg",
      "iterations": 200000,
      "totalMs": 156.182,
      "avgUsPerExec": 0.781
    },
    {
      "scenario": "5 hooks, 3 args",
      "iterations": 200000,
      "totalMs": 88.307,
      "avgUsPerExec": 0.442
    },
    {
      "scenario": "5 hooks, 3 args + callback",
      "iterations": 200000,
      "totalMs": 98.874,
      "avgUsPerExec": 0.494
    },
    {
      "scenario": "10 hooks, 3 args + callback",
      "iterations": 200000,
      "totalMs": 158.878,
      "avgUsPerExec": 0.794
    }
  ]
}
```

After:

```
{
  "results": [
    {
      "scenario": "1 hook, 1 arg",
      "iterations": 200000,
      "totalMs": 45.687,
      "avgUsPerExec": 0.228
    },
    {
      "scenario": "5 hooks, 1 arg",
      "iterations": 200000,
      "totalMs": 81.51,
      "avgUsPerExec": 0.408
    },
    {
      "scenario": "10 hooks, 1 arg",
      "iterations": 200000,
      "totalMs": 128.164,
      "avgUsPerExec": 0.641
    },
    {
      "scenario": "5 hooks, 3 args",
      "iterations": 200000,
      "totalMs": 75.607,
      "avgUsPerExec": 0.378
    },
    {
      "scenario": "5 hooks, 3 args + callback",
      "iterations": 200000,
      "totalMs": 77.089,
      "avgUsPerExec": 0.385
    },
    {
      "scenario": "10 hooks, 3 args + callback",
      "iterations": 200000,
      "totalMs": 121.383,
      "avgUsPerExec": 0.607
    }
  ]
}
```

This difference is significant enough to show up in Mongoose's `saveSimple()` benchmark, which we have been striving to optimize.