### PR TITLE
feat: filter hooks per call in createWrapper via getOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,30 @@ assert.equal(obj.tofu, 'no');
 assert.equal(result, obj);
 ```
 
+### It supports filtering hooks per call with getOptions
+
+Direct `wrap()` callers can pass the same `getOptions` option that
+`createWrapper()` accepts. `getOptions` receives the call arguments and
+returns options for `execPre()`/`execPost()`, either a single `{ filter }`
+applied to both phases or separate `{ pre, post }` options.
+
+```javascript
+const execed = [];
+
+const audit = function() { execed.push('audit'); };
+audit.skipMe = true;
+hooks.pre('cook', audit);
+
+hooks.pre('cook', function() { execed.push('validate'); });
+
+const result = await hooks.wrap('cook', o => o, null, ['eggs'], {
+  getOptions: (args) => args[0] === 'eggs' ? { filter: hook => !hook.fn.skipMe } : {}
+});
+
+assert.deepStrictEqual(execed, ['validate']);
+assert.equal(result, 'eggs');
+```
+
 ## createWrapper()
 
 ### It wraps wrap() into a callable function

--- a/README.md
+++ b/README.md
@@ -350,6 +350,37 @@ assert.equal(obj.tofu, 'no');
 assert.equal(result, obj);
 ```
 
+### It supports filtering hooks per call with getOptions
+
+You can pass a `getOptions` function to `createWrapper()` to choose which
+hooks run on each call. `getOptions` receives the arguments the wrapped
+function was called with and returns options for `execPre()`/`execPost()`.
+Return a single `{ filter }` to apply to both pre and post hooks, or
+`{ pre, post }` to filter them separately. `createWrapperSync()` supports
+the same option. This is how Mongoose skips user-defined middleware for a
+single operation.
+
+```javascript
+const execed = [];
+
+const audit = function() { execed.push('audit'); };
+audit.skipMe = true;
+hooks.pre('cook', audit);
+
+hooks.pre('cook', function() { execed.push('validate'); });
+
+const cook = hooks.createWrapper('cook', o => o, null, {
+  getOptions: (args) => {
+    const options = args[args.length - 1] || {};
+    return options.skipMiddleware ? { filter: hook => !hook.fn.skipMe } : {};
+  }
+});
+
+// Skips the `audit` hook because the call passes `skipMiddleware: true`
+await cook({}, { skipMiddleware: true });
+assert.deepStrictEqual(execed, ['validate']);
+```
+
 ## clone()
 
 ### It clones a Kareem object

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,31 +1,61 @@
 declare module "kareem" {
+  interface FilterOption {
+    /** Predicate that receives each registered hook and returns whether to run it. */
+    filter?: (hook: any) => boolean;
+  }
+
+  interface ExecPostOptions extends FilterOption {
+    /** Error to pass to error-handling middleware. */
+    error?: Error;
+    /** Force a consistent number of arguments passed to each post hook. */
+    numCallbackParams?: number;
+  }
+
+  /**
+   * Result of a `getOptions` callback: either a single `{ filter }` applied to both
+   * pre and post hooks, or separate `{ pre, post }` options.
+   */
+  type GetOptionsResult = FilterOption | { pre?: FilterOption; post?: FilterOption };
+
+  interface CreateWrapperSyncOptions {
+    /** Receives the wrapper arguments and returns options for execPreSync/execPostSync. */
+    getOptions?: (args: any[]) => GetOptionsResult;
+  }
+
+  interface CreateWrapperOptions extends Record<string, any> {
+    /** Receives the wrapper arguments and returns options for execPre/execPost. */
+    getOptions?: (args: any[]) => GetOptionsResult;
+  }
+
   export default class Kareem {
-    static skipWrappedFunction(): SkipWrappedFunction;
-    static overwriteMiddlewareResult(): OverwriteMiddlewareResult;
-    static overwriteArguments(): OverwriteArguments;
+    static skipWrappedFunction(...args: any[]): SkipWrappedFunction;
+    static overwriteResult(...args: any[]): OverwriteResult;
+    static overwriteArguments(...args: any[]): OverwriteArguments;
 
     pre(name: string | RegExp, fn: Function): this;
     pre(name: string | RegExp, options: Record<string, any>, fn: Function, error?: any, unshift?: boolean): this;
     post(name: string | RegExp, fn: Function): this;
     post(name: string | RegExp, options: Record<string, any>, fn: Function, unshift?: boolean): this;
+    postError(name: string | RegExp, fn: Function, unshift?: boolean): this;
+    postError(name: string | RegExp, options: Record<string, any>, fn: Function, unshift?: boolean): this;
 
     clone(): Kareem;
     merge(other: Kareem, clone?: boolean): this;
 
-    createWrapper(name: string, fn: Function, context?: any, options?: Record<string, any>): Function;
-    createWrapperSync(name: string, fn: Function): Function;
+    createWrapper(name: string, fn: Function, context?: any, options?: CreateWrapperOptions): Function;
+    createWrapperSync(name: string, fn: Function, context?: any, options?: CreateWrapperSyncOptions): Function;
     hasHooks(name: string): boolean;
-    filter(fn: Function): Kareem;
+    filter(fn: (hook: any) => boolean): Kareem;
 
-    wrap(name: string, fn: Function, context: any, args: any[], options?: Record<string, any>): Function;
+    wrap(name: string, fn: Function, context: any, args: any[], options?: CreateWrapperOptions): Promise<any>;
 
-    execPostSync(name: string, context: any, args: any[]): any;
-    execPost(name: string, context: any, args: any[], options?: Record<string, any>, callback?: Function): void;
-    execPreSync(name: string, context: any, args: any[]): any;
-    execPre(name: string, context: any, args: any[], callback?: Function): void;
+    execPostSync(name: string, context: any, args: any[], options?: FilterOption): any[];
+    execPost(name: string, context: any, args: any[], options?: ExecPostOptions): Promise<any[]>;
+    execPreSync(name: string, context: any, args: any[], options?: FilterOption): any[];
+    execPre(name: string, context: any, args: any[], options?: FilterOption): Promise<any[]>;
   }
 
   class SkipWrappedFunction {}
-  class OverwriteMiddlewareResult {}
+  class OverwriteResult {}
   class OverwriteArguments {}
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,8 +42,8 @@ declare module "kareem" {
     clone(): Kareem;
     merge(other: Kareem, clone?: boolean): this;
 
-    createWrapper(name: string, fn: Function, context?: any, options?: CreateWrapperOptions): Function;
-    createWrapperSync(name: string, fn: Function, context?: any, options?: CreateWrapperSyncOptions): Function;
+    createWrapper<T extends (...args: any[]) => any>(name: string, fn: T, context?: any, options?: CreateWrapperOptions): (...args: Parameters<T>) => Promise<Awaited<ReturnType<T>>>;
+    createWrapperSync<T extends (...args: any[]) => any>(name: string, fn: T, context?: any, options?: CreateWrapperSyncOptions): (...args: Parameters<T>) => ReturnType<T>;
     hasHooks(name: string): boolean;
     filter(fn: (hook: any) => boolean): Kareem;
 

--- a/index.js
+++ b/index.js
@@ -316,21 +316,27 @@ Kareem.prototype.createWrapperSync = function(name, fn, context, options) {
  * @param {Function} fn The function for the hook
  * @param {*} context Overwrite the "this" for the hook
  * @param {Array} args Apply custom arguments to the hook
- * @param {Object} options Additional options for the hook
- * @returns {void}
+ * @param {Object} [options] Additional options for the hook
+ * @param {Function} [options.getOptions] Function that receives `args` and returns options for execPre/execPost. Can return `{ filter }` for both, or `{ pre: { filter }, post: { filter } }` for separate options.
+ * @returns {Promise<any>} The wrapped function's result, potentially modified by post hooks
  */
 Kareem.prototype.wrap = async function wrap(name, fn, context, args, options) {
+  const getOptions = options?.getOptions;
+  const execOptions = typeof getOptions === 'function' ? getOptions(args) : {};
+  const preOptions = execOptions.pre ?? execOptions;
+  const postOptions = execOptions.post ?? execOptions;
+
   let ret;
   let skipWrappedFunction = false;
   let modifiedArgs = args;
   try {
-    modifiedArgs = await this.execPre(name, context, args);
+    modifiedArgs = await this.execPre(name, context, args, preOptions);
   } catch (error) {
     if (error instanceof Kareem.skipWrappedFunction) {
       ret = error.args;
       skipWrappedFunction = true;
     } else {
-      await this.execPost(name, context, args, { ...options, error });
+      await this.execPost(name, context, args, { ...options, ...postOptions, error });
     }
   }
 
@@ -338,7 +344,7 @@ Kareem.prototype.wrap = async function wrap(name, fn, context, args, options) {
     ret = await fn.apply(context, modifiedArgs);
   }
 
-  ret = await this.execPost(name, context, [ret], options);
+  ret = await this.execPost(name, context, [ret], { ...options, ...postOptions });
 
   return ret[0];
 };
@@ -397,6 +403,7 @@ Kareem.prototype.hasHooks = function(name) {
  * @param {Function} fn The function to wrap
  * @param {*} context Overwrite the "this" for the hook
  * @param {Object} [options]
+ * @param {Function} [options.getOptions] Function that receives the wrapper arguments and returns options for execPre/execPost. Can return `{ filter }` for both, or `{ pre: { filter }, post: { filter } }` for separate options.
  * @returns {Function} The wrapped function
  */
 Kareem.prototype.createWrapper = function(name, fn, context, options) {

--- a/index.js
+++ b/index.js
@@ -401,7 +401,7 @@ Kareem.prototype.hasHooks = function(name) {
  * Create a Wrapper for "fn" on "name" and return the wrapped function
  * @param {String} name The name of the hook
  * @param {Function} fn The function to wrap
- * @param {*} context Overwrite the "this" for the hook
+ * @param {*} context Overwrite the "this" for the hook. If null/undefined, uses the calling context.
  * @param {Object} [options]
  * @param {Function} [options.getOptions] Function that receives the wrapper arguments and returns options for execPre/execPost. Can return `{ filter }` for both, or `{ pre: { filter }, post: { filter } }` for separate options.
  * @returns {Function} The wrapped function
@@ -413,7 +413,7 @@ Kareem.prototype.createWrapper = function(name, fn, context, options) {
     return fn;
   }
   return function kareemWrappedFunction() {
-    const _context = context || this;
+    const _context = context ?? this;
     return _this.wrap(name, fn, _context, Array.from(arguments), options);
   };
 };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.3.0",
   "description": "Next-generation take on pre/post function hooks",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "lint": "eslint .",
     "test": "mocha ./test/*",

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -285,6 +285,23 @@ describe('wrap()', function() {
     assert.equal(obj.tofu, 'no');
     assert.equal(result, obj);
   });
+
+  it('supports filtering hooks per call with getOptions', async function() {
+    const execed = [];
+
+    const audit = function() { execed.push('audit'); };
+    audit.skipMe = true;
+    hooks.pre('cook', audit);
+
+    hooks.pre('cook', function() { execed.push('validate'); });
+
+    const result = await hooks.wrap('cook', o => o, null, ['eggs'], {
+      getOptions: (args) => args[0] === 'eggs' ? { filter: hook => !hook.fn.skipMe } : {}
+    });
+
+    assert.deepStrictEqual(execed, ['validate']);
+    assert.equal(result, 'eggs');
+  });
 });
 
 //

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -340,6 +340,35 @@ describe('createWrapper()', function() {
 
     assert.equal(result, obj);
   });
+
+  /* You can pass a `getOptions` function to `createWrapper()` to choose which
+   * hooks run on each call. `getOptions` receives the arguments the wrapped
+   * function was called with and returns options for `execPre()`/`execPost()`.
+   * Return a single `{ filter }` to apply to both pre and post hooks, or
+   * `{ pre, post }` to filter them separately. `createWrapperSync()` supports
+   * the same option. This is how Mongoose skips user-defined middleware for a
+   * single operation.
+   */
+  it('supports filtering hooks per call with getOptions', async function() {
+    const execed = [];
+
+    const audit = function() { execed.push('audit'); };
+    audit.skipMe = true;
+    hooks.pre('cook', audit);
+
+    hooks.pre('cook', function() { execed.push('validate'); });
+
+    const cook = hooks.createWrapper('cook', o => o, null, {
+      getOptions: (args) => {
+        const options = args[args.length - 1] || {};
+        return options.skipMiddleware ? { filter: hook => !hook.fn.skipMe } : {};
+      }
+    });
+
+    // Skips the `audit` hook because the call passes `skipMiddleware: true`
+    await cook({}, { skipMiddleware: true });
+    assert.deepStrictEqual(execed, ['validate']);
+  });
 });
 
 //

--- a/test/wrap.test.js
+++ b/test/wrap.test.js
@@ -612,6 +612,112 @@ describe('wrap()', function() {
     assert.deepStrictEqual(execed, ['pre1', 'pre2', 'fn', 'post2']);
   });
 
+  it('async wrappers support getOptions to filter hooks', async function() {
+    const execed = [];
+
+    const fn1 = function() { execed.push('pre1'); };
+    fn1.skipMe = true;
+    hooks.pre('cook', fn1);
+
+    const fn2 = function() { execed.push('pre2'); };
+    hooks.pre('cook', fn2);
+
+    const postFn1 = function() { execed.push('post1'); };
+    postFn1.skipMe = true;
+    hooks.post('cook', postFn1);
+
+    const postFn2 = function() { execed.push('post2'); };
+    hooks.post('cook', postFn2);
+
+    const wrapper = hooks.createWrapper('cook', function(doc) {
+      execed.push('fn');
+      return doc;
+    }, null, {
+      getOptions: (args) => {
+        const opts = args[1] || {};
+        if (opts.skipMiddleware) {
+          return { filter: hook => !hook.fn.skipMe };
+        }
+        return {};
+      }
+    });
+
+    // Without skipMiddleware option, all hooks run
+    await wrapper({ name: 'test' }, {});
+    assert.deepStrictEqual(execed, ['pre1', 'pre2', 'fn', 'post1', 'post2']);
+
+    // With skipMiddleware option, filtered hooks are skipped
+    execed.length = 0;
+    await wrapper({ name: 'test' }, { skipMiddleware: true });
+    assert.deepStrictEqual(execed, ['pre2', 'fn', 'post2']);
+  });
+
+  it('async wrappers support separate pre/post options from getOptions', async function() {
+    const execed = [];
+
+    const fn1 = function() { execed.push('pre1'); };
+    fn1.skipMe = true;
+    hooks.pre('cook', fn1);
+
+    const fn2 = function() { execed.push('pre2'); };
+    hooks.pre('cook', fn2);
+
+    const postFn1 = function() { execed.push('post1'); };
+    postFn1.skipMe = true;
+    hooks.post('cook', postFn1);
+
+    const postFn2 = function() { execed.push('post2'); };
+    hooks.post('cook', postFn2);
+
+    const wrapper = hooks.createWrapper('cook', function(doc) {
+      execed.push('fn');
+      return doc;
+    }, null, {
+      getOptions: (args) => {
+        const opts = args[1] || {};
+        return {
+          pre: opts.skipPre ? { filter: hook => !hook.fn.skipMe } : {},
+          post: opts.skipPost ? { filter: hook => !hook.fn.skipMe } : {}
+        };
+      }
+    });
+
+    // Skip only pre hooks
+    await wrapper({ name: 'test' }, { skipPre: true });
+    assert.deepStrictEqual(execed, ['pre2', 'fn', 'post1', 'post2']);
+
+    // Skip only post hooks
+    execed.length = 0;
+    await wrapper({ name: 'test' }, { skipPost: true });
+    assert.deepStrictEqual(execed, ['pre1', 'pre2', 'fn', 'post2']);
+  });
+
+  it('async wrappers apply the getOptions filter to error handlers', async function() {
+    const execed = [];
+
+    hooks.pre('cook', function() {
+      throw new Error('fail');
+    });
+
+    const errFn1 = function() { execed.push('errorHandler1'); };
+    errFn1.skipMe = true;
+    hooks.postError('cook', errFn1);
+
+    const errFn2 = function() { execed.push('errorHandler2'); };
+    hooks.postError('cook', errFn2);
+
+    const wrapper = hooks.createWrapper('cook', function() {
+      execed.push('fn');
+    }, null, {
+      getOptions: () => ({ filter: hook => !hook.fn.skipMe })
+    });
+
+    await assert.rejects(() => wrapper(), /fail/);
+
+    // errFn1 is filtered out, errFn2 still runs, and the wrapped fn never runs
+    assert.deepStrictEqual(execed, ['errorHandler2']);
+  });
+
   it('sync wrappers use provided context over calling context', function() {
     const providedContext = { name: 'provided' };
     const callingContext = { name: 'calling' };

--- a/test/wrap.test.js
+++ b/test/wrap.test.js
@@ -770,4 +770,62 @@ describe('wrap()', function() {
     assert.strictEqual(fnContext, callingContext);
     assert.strictEqual(postContext, callingContext);
   });
+
+  it('sync wrappers preserve explicit falsey contexts', function() {
+    for (const providedContext of [0, '', false]) {
+      const callingContext = { name: 'calling' };
+      let preContext = null;
+      let fnContext = null;
+      let postContext = null;
+
+      hooks = new Kareem();
+      hooks.pre('init', function() {
+        preContext = this;
+      });
+
+      hooks.post('init', function() {
+        postContext = this;
+      });
+
+      const wrapper = hooks.createWrapperSync('init', function() {
+        fnContext = this;
+        return 'result';
+      }, providedContext);
+
+      wrapper.call(callingContext);
+
+      assert.strictEqual(preContext, providedContext);
+      assert.strictEqual(fnContext, providedContext);
+      assert.strictEqual(postContext, providedContext);
+    }
+  });
+
+  it('async wrappers preserve explicit falsey contexts', async function() {
+    for (const providedContext of [0, '', false]) {
+      const callingContext = { name: 'calling' };
+      let preContext = null;
+      let fnContext = null;
+      let postContext = null;
+
+      hooks = new Kareem();
+      hooks.pre('save', function() {
+        preContext = this;
+      });
+
+      hooks.post('save', function() {
+        postContext = this;
+      });
+
+      const wrapper = hooks.createWrapper('save', function() {
+        fnContext = this;
+        return 'result';
+      }, providedContext);
+
+      await wrapper.call(callingContext);
+
+      assert.strictEqual(preContext, providedContext);
+      assert.strictEqual(fnContext, providedContext);
+      assert.strictEqual(postContext, providedContext);
+    }
+  });
 });


### PR DESCRIPTION
re #43 and #44

Adds `getOptions` support to `createWrapper()`/`wrap()`, mirroring #44 for `createWrapperSync()`. `wrap()` reads per-call options from `options.getOptions(args)` and passes the `filter` to `execPre`/`execPost` (including the error path), so `createWrapper`-based hooks (Mongoose statics and methods) can skip user middleware for a single call. Without `getOptions`, nothing changes.

Also fixes `index.d.ts`, which had drifted from the runtime: corrected the `execPre`/`execPost`/`*Sync` signatures, added `getOptions` and `postError`, renamed `overwriteMiddlewareResult` -> `overwriteResult` to match the real export, and wired up the missing `types` field.

Heads up: the `overwriteResult` rename is a type-level change for anything referencing `Kareem.OverwriteMiddlewareResult` (Mongoose's `types/` does). I have the matching Mongoose change ready.

Also documented `getOptions`.